### PR TITLE
chore: use relative whisper model path

### DIFF
--- a/config/app.yaml
+++ b/config/app.yaml
@@ -1,6 +1,7 @@
 paths:
   data_root: "./data/sessions"
-  whisper_model_dir: "/Users/benjaminpoersch/Projekte/XEXPERIMENTE/TransRapport_V2/whisperTurboCT2"
+  # Local path to Faster-Whisper CT2 weights (override via SERAPI_WHISPER_MODEL_DIR)
+  whisper_model_dir: "./models/whisper/faster-whisper-large-v3"
   # Marker-Pfad: falls Marker in Nachbar-Repo liegen, z.B. ../markers_repo/markers
   markers_root: "./markers"
 


### PR DESCRIPTION
## Summary
- use repo-relative path for default Whisper CT2 model

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b790c623848322a67609e8cc86987a